### PR TITLE
Fix bug when release summary has underscores

### DIFF
--- a/notifier.py
+++ b/notifier.py
@@ -7,7 +7,7 @@ from os import environ
 app = Flask(__name__)
 
 def notify_rocketchat(app, release, release_summary, sha, user):
-    api.send_message(':new: *Deis({env})* {app} #{release} - _{release_summary}_'
+    api.send_message(':new: *Deis({env})* {app} #{release} - {release_summary}'
             .format(app=app, release=release, release_summary=release_summary, env=env), topic)
 
 @app.route('/notify_deploy', methods=['POST'])


### PR DESCRIPTION
A release summary containing underscores does not display properly: NEW_RELIC_APP_NAME would appear with NEW in italic and the rest would be RELIC_APP_NAME_.